### PR TITLE
Properly report empty file attributes

### DIFF
--- a/bin/classes/attribute/io/FileToJson.php
+++ b/bin/classes/attribute/io/FileToJson.php
@@ -15,6 +15,7 @@ class FileToJson
 	
 	public function getRaw() {
 		if ($this->file === null) { return null; }
+		if ($this->file->value === null) { return null; }
 		
 		return Array(
 			'type'     => 'file',

--- a/bin/classes/attribute/io/FileToJson.php
+++ b/bin/classes/attribute/io/FileToJson.php
@@ -9,19 +9,24 @@ class FileToJson
 	
 	private $file;
 	
-	public function __construct($model) {
+	public function __construct($model)
+	{
 		$this->file = $model;
 	}
 	
-	public function getRaw() {
-		if ($this->file === null) { return null; }
-		if ($this->file->value === null) { return null; }
+	public function getRaw()
+	{
+		if ($this->file === null) {
+			return null;
+		}
+		if ($this->file->value === null) {
+			return null;
+		}
 		
-		return Array(
+		return array(
 			'type'     => 'file',
-			'preview'  => (string) url('image',    'attribute', $this->file->attr->_id, $this->file->user->_id, ['t' => $this->file->modified])->absolute(),
+			'preview'  => (string) url('image', 'attribute', $this->file->attr->_id, $this->file->user->_id, ['t' => $this->file->modified])->absolute(),
 			'download' => (string) url('download', 'attribute', $this->file->attr->_id, $this->file->user->_id, ['t' => $this->file->modified])->absolute()
 		);
 	}
-	
 }

--- a/bin/classes/attribute/io/FileToJson.php
+++ b/bin/classes/attribute/io/FileToJson.php
@@ -25,8 +25,20 @@ class FileToJson
 		
 		return array(
 			'type'     => 'file',
-			'preview'  => (string) url('image', 'attribute', $this->file->attr->_id, $this->file->user->_id, ['t' => $this->file->modified])->absolute(),
-			'download' => (string) url('download', 'attribute', $this->file->attr->_id, $this->file->user->_id, ['t' => $this->file->modified])->absolute()
+			'preview'  => (string) url(
+				'image',
+				'attribute',
+				$this->file->attr->_id,
+				$this->file->user->_id,
+				['t' => $this->file->modified]
+			)->absolute(),
+			'download' => (string) url(
+				'download',
+				'attribute',
+				$this->file->attr->_id,
+				$this->file->user->_id,
+				['t' => $this->file->modified]
+			)->absolute()
 		);
 	}
 }

--- a/bin/controllers/image.php
+++ b/bin/controllers/image.php
@@ -43,10 +43,12 @@ class ImageController extends Controller
 		$icon = $app->icon? storage()->get($app->icon) : storage()->get(self::DEFAULT_APP_ICON);
 		
 		try {
-			$file = storage()->dir(spitfire\core\Environment::get('uploads.directory'))->open($size . '_' . $icon->basename() . '.jpg');
+			$file = storage()->dir(spitfire\core\Environment::get('uploads.directory'))
+				->open($size . '_' . $icon->basename() . '.jpg');
 		}
 		catch (FileNotFoundException$e) {
-			$file = storage()->dir(spitfire\core\Environment::get('uploads.directory'))->make($size . '_' . $icon->basename() . '.jpg');
+			$file = storage()->dir(spitfire\core\Environment::get('uploads.directory'))
+				->make($size . '_' . $icon->basename() . '.jpg');
 			
 			$img  = media()->load($icon)->poster();
 			$img->fit($size, $size);

--- a/bin/controllers/image.php
+++ b/bin/controllers/image.php
@@ -5,6 +5,7 @@ use spitfire\exceptions\PrivateException;
 use spitfire\exceptions\PublicException;
 use spitfire\io\Image;
 use spitfire\storage\objectStorage\FileInterface;
+use spitfire\storage\objectStorage\NodeInterface;
 
 ini_set('memory_limit', '512M');
 
@@ -142,19 +143,13 @@ class ImageController extends Controller
 			throw new PublicException('Invalid user / attribute id');
 		}
 		
-		try {
-			if (!empty($attr->value)) {
-				/*@var $file \spitfire\storage\drive\File*/
-				$file = storage($attr->value);
-			}
-			else {
-				throw new Exception('No file', 1811031627);
-			}
-		} 
-		catch (Exception $ex) {
-			$file = storage()->get('app://' . $attr->value);
+		if ($attr->value === null) {
+			throw new PublicException('No file', 404);
 		}
 		
+		/*@var $file \spitfire\storage\drive\File*/
+		$file = storage()->get($attr->value);
+		assert($file instanceof NodeInterface);
 		
 		/*
 		 * Define the filename of the target, we store the thumbs for the objects


### PR DESCRIPTION
Up until now PHPAS would report the attribute wrongly if the
value was empty. This would cause apps to load broken images.