### PR TITLE
Resolve issue where if you Login on any username that doesnt exist, it would throw an error.

### DIFF
--- a/bin/controllers/user.php
+++ b/bin/controllers/user.php
@@ -235,6 +235,10 @@ class UserController extends BaseController
 			
 			$user = $query->first();
 			
+			if(!isset($user)){
+				$this->view->set('message', 'Username or password did not match');
+			}
+			
 			#Check whether the user was banned
 			$banned = $user->isSuspended();
 			

--- a/bin/controllers/user.php
+++ b/bin/controllers/user.php
@@ -236,12 +236,9 @@ class UserController extends BaseController
 			$user = $query->first();
 			
 			if ($user && $user->checkPassword($_POST['password'])) {
-
 				#Check whether the user was banned
 				$banned = $user->isSuspended();
-
-
-
+				
 				if ($banned) {
 					$ex = new LoginException('Your account was suspended, login is disabled.', 401);
 					$ex->setUserID($user->_id);
@@ -250,7 +247,7 @@ class UserController extends BaseController
 					throw $ex;
 				}
 				
-				if( $user->disabled !== null){
+				if ($user->disabled !== null) {
 					$ex = new LoginException('This account has been disabled permanently.', 401);
 					$ex->setUserID($user->_id);
 					throw $ex;

--- a/bin/controllers/user.php
+++ b/bin/controllers/user.php
@@ -235,28 +235,26 @@ class UserController extends BaseController
 			
 			$user = $query->first();
 			
-			if(!isset($user)){
-				$this->view->set('message', 'Username or password did not match');
-			}
-			
-			#Check whether the user was banned
-			$banned = $user->isSuspended();
-			
-			if ($banned) {
-				$ex = new LoginException('Your account was suspended, login is disabled.', 401);
-				$ex->setUserID($user->_id);
-				$ex->setReason($banned->reason);
-				$ex->setExpiry($banned->expires);
-				throw $ex;
-			}
-			
-			
-			if ($user && $user->disabled !== null) {
-				$ex = new LoginException('This account has been disabled permanently.', 401);
-				$ex->setUserID($user->_id);
-				throw $ex;
-			}
-			elseif ($user && $user->checkPassword($_POST['password'])) {
+			if ($user && $user->checkPassword($_POST['password'])) {
+
+				#Check whether the user was banned
+				$banned = $user->isSuspended();
+
+
+
+				if ($banned) {
+					$ex = new LoginException('Your account was suspended, login is disabled.', 401);
+					$ex->setUserID($user->_id);
+					$ex->setReason($banned->reason);
+					$ex->setExpiry($banned->expires);
+					throw $ex;
+				}
+				
+				if( $user->disabled !== null){
+					$ex = new LoginException('This account has been disabled permanently.', 401);
+					$ex->setUserID($user->_id);
+					throw $ex;
+				}
 				
 				/**
 				 * Create a fresh session whenever a user logs in. Make sure that the session


### PR DESCRIPTION
This PR changes the checks for suspension and bans to after the password has been validated. 

a) It Is an security risk if anyone could just try to use an username to check their ban status via an login page without even an password

b) the isSuspended() function couldn't handle an not found user, and successful login validation ensures that an user is found. 